### PR TITLE
Removed "package" from the link

### DIFF
--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -22,7 +22,7 @@ Before you can use dependency injection, you must install the following NuGet pa
 
 - [Microsoft.Azure.Functions.Extensions](https://www.nuget.org/packages/Microsoft.Azure.Functions.Extensions/)
 
-- [Microsoft.NET.Sdk.Functions package](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/) version 1.0.28 or later
+- [Microsoft.NET.Sdk.Functions](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/) package version 1.0.28 or later
 
 ## Register services
 


### PR DESCRIPTION
It makes it more user friendly to right click and copy the package name because the "package" word is no longer being copied.