### PR TITLE
Update concept-conditional-access-cloud-apps.md

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
@@ -115,6 +115,10 @@ In addition to the Microsoft apps, administrators can add any Azure AD registere
 - [Custom applications not in the gallery](../manage-apps/add-non-gallery-app.md)
 - [Legacy applications published through app delivery controllers and networks](../manage-apps/secure-hybrid-access.md)
 
+> [!NOTE]
+> Since Conditional access policy sets the requirements for accessing a service you are not able to apply it to a client (public/native) application. Other words the policy is not set directly on a client (public/native) application, but is applied when a client calls a service. For example, a policy set on SharePoint service applies to the clients calling SharePoint. A policy set on Exchange applies to the attempt to access the email using Outlook client. That is why client (public/native) applications are not available for selection in the Cloud Apps picker and Conditional Access option is not available in the application settings for the client (public/native) application registered in your tenant. 
+
+
 ## User actions
 
 User actions are tasks that can be performed by a user. The only currently supported action is **Register security information**, which allows Conditional Access policy to enforce when users who are enabled for combined registration attempt to register their security information. More information can be found in the article, [Combined security information registration](../authentication/concept-registration-mfa-sspr-combined.md).


### PR DESCRIPTION
to help the Cx to understand why some apps cant have AAD CA be applied to them, proposing to add this Note in the article.

> [!NOTE]
> Since Conditional access policy sets the requirements for accessing a service, you are not able to apply it to a client (public/native) application. Other words, the policy is not set directly on a client (public/native) application, but is applied when a client calls the service. For example, a policy set on SharePoint service applies to the clients calling SharePoint. A policy set on Exchange applies to the attempt to access the email using Outlook client. That is why client (public/native) applications are not available for selection in the Cloud Apps picker and Conditional Access option is not available in the application settings for the client (public/native) application registered in your tenant.