### PR TITLE
Update web-sites-integrate-with-vnet.md

### DIFF
--- a/articles/app-service/web-sites-integrate-with-vnet.md
+++ b/articles/app-service/web-sites-integrate-with-vnet.md
@@ -122,7 +122,7 @@ The only operation you can take in the app view of your VNet Integration instanc
 
 The App Service plan VNet Integration UI shows you all of the VNet integrations used by the apps in your App Service plan. To see details on each VNet, select the VNet you're interested in. There are two actions you can perform here for gateway-required VNet Integration:
 
-* **Sync network**: The sync network operation is used only for the gateway-dependent VNet Integration feature. Performing a sync network operation ensures that your certificates and network information are in sync. If you add or change the DNS of your VNet, perform a sync network operation. This operation restarts any apps that use this VNet.
+* **Sync network**: The sync network operation is used only for the gateway-dependent VNet Integration feature. Performing a sync network operation ensures that your certificates and network information are in sync. If you add or change the DNS of your VNet, perform a sync network operation. This operation restarts any apps that use this VNet. This operation will not work if you are using an app and a vnet belonging to different subscriptions.
 * **Add routes**: Adding routes drives outbound traffic into your VNet.
 
 ### Gateway-required VNet Integration routing


### PR DESCRIPTION
Comment based on a case I just had where a customer found a way to do gateway-required vnet integration between an App and a Vnet in different subscriptions.
The configuration was allowed when he used ARM templates, and he acquired the initial cert by create a local app (same sub as the vnet) deleting it and using the managed cert on the new App (different sub from the vnet). everything functioned up until the network sync attempt. 

The limitation of integrating the app with a vnet from another sub is only specified in regional integration limitations, but not for gateway-required integration. 