### PR TITLE
Run the function using the host

### DIFF
--- a/includes/functions-run-function-test-local-cli.md
+++ b/includes/functions-run-function-test-local-cli.md
@@ -12,7 +12,7 @@ Run your function by starting the local Azure Functions runtime host from the *L
 
 ::: zone pivot="programming-language-csharp,programming-language-powershell,programming-language-javascript,programming-language-python"
 ```
-func start
+func host start
 ```
 ::: zone-end
 


### PR DESCRIPTION
I'm not sure about this. But shouldn't the start command use 'host start' instead of just 'start'?