### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#54809

### DIFF
--- a/articles/active-directory-b2c/analytics-with-application-insights.md
+++ b/articles/active-directory-b2c/analytics-with-application-insights.md
@@ -167,7 +167,7 @@ Call `AppInsights-SignInRequest` as orchestration step 2 to track that a sign-in
 
 ```xml
 <!-- Track that we have received a sign in request -->
-<OrchestrationStep Order="1" Type="ClaimsExchange">
+<OrchestrationStep Order="2" Type="ClaimsExchange">
   <ClaimsExchanges>
     <ClaimsExchange Id="TrackSignInRequest" TechnicalProfileReferenceId="AppInsights-SignInRequest" />
   </ClaimsExchanges>


### PR DESCRIPTION
Changed `<OrchestrationStep Order="1" Type="ClaimsExchange">` to `<OrchestrationStep Order="2" Type="ClaimsExchange">` to align with the above line "Call `AppInsights-SignInRequest` as orchestration step 2 to track that a sign-in/sign-up request has been received:"