### PR TITLE
Update | AADSTS50199 | CmsiInterrupt details

### DIFF
--- a/articles/active-directory/develop/reference-aadsts-error-codes.md
+++ b/articles/active-directory/develop/reference-aadsts-error-codes.md
@@ -169,7 +169,12 @@ Search on the numeric part of the returned error code.  For example, if you rece
 | AADSTS50187 | DeviceInformationNotProvided - The service failed to perform device authentication. |
 | AADSTS50196 | LoopDetected - A client loop has been detected. Check the app’s logic to ensure that token caching is implemented, and that error conditions are handled correctly.  The app has made too many of the same request in too short a period, indicating that it is in a faulty state or is abusively requesting tokens. |
 | AADSTS50197 | ConflictingIdentities - The user could not be found. Try signing in again. |
-| AADSTS50199 | CmsiInterrupt - For security reasons, user confirmation is required for this request.  Because this is an "interaction_required" error, the client should do interactive auth.  This occurs because a system webview has been used to request a token for a native application - the user must be prompted to ask if this was actually the app they meant to sign into.|
+| AADSTS50199 | CmsiInterrupt - For security reasons, user confirmation is required for this request.  Because this is an "interaction_required" error, the client should do interactive auth.  This occurs because a system webview has been used to request a token for a native application - the user must be prompted to ask if this was actually the app they meant to sign into. To avoid this prompt, the redirect URI should be part of the following safe list: 
+http://
+https://
+msauth://(iOS only)
+msauthv2://(iOS only)
+chrome-extension:// (desktop Chrome browser only) |
 | AADSTS51000 | RequiredFeatureNotEnabled - The feature is disabled. |
 | AADSTS51001 | DomainHintMustbePresent - Domain hint must be present with on-premises security identifier or on-premises UPN. |
 | AADSTS51004 | UserAccountNotInDirectory - The user account doesn’t exist in the directory. |


### PR DESCRIPTION
In the AADSTS50199 details we should specify how this prompt could be avoided, for example:

To avoid this prompt, the redirect URI should be part of the following safe list: 
http://
https://
msauth://(iOS only)
msauthv2://(iOS only)