### PR TITLE
Update sql-database-managed-instance-get-started-restore.md

### DIFF
--- a/articles/sql-database/sql-database-managed-instance-get-started-restore.md
+++ b/articles/sql-database/sql-database-managed-instance-get-started-restore.md
@@ -88,6 +88,7 @@ In SSMS, follow these steps to restore the Wide World Importers database to your
 
 ## Next steps
 
+- If, at step 5, a database restore is terminated with the message ID 22003, create a new backup file containing backup checksums and perform the restore again. See [Enable or disable backup checksums during backup or restore](https://docs.microsoft.com/en-us/sql/relational-databases/backup-restore/enable-or-disable-backup-checksums-during-backup-or-restore-sql-server).
 - For troubleshooting a backup to a URL, see [SQL Server Backup to URL Best Practices and Troubleshooting](https://docs.microsoft.com/sql/relational-databases/backup-restore/sql-server-backup-to-url-best-practices-and-troubleshooting).
 - For an overview of app connection options, see [Connect your applications to Managed Instance](sql-database-managed-instance-connect-app.md).
 - To query using your favorite tools or languages, see [Quickstarts: Azure SQL Database Connect and Query](sql-database-connect-query.md).


### PR DESCRIPTION
I recently received the error message below when restoring a backup file to an Azure SQL Managed Instance. Creating a new backup file containing backup checksums resolved the issue.

Msg 22003, Level 16, State 1, Line 21
Stale/aborted version cleanup was aborted for database id '5' due to database shutdown.
Msg 3013, Level 16, State 1, Line 21
RESTORE DATABASE is terminating abnormally.