### PR TITLE
Reflect SQL 2019 or later support policy for Auto bacj

### DIFF
--- a/articles/virtual-machines/windows/sql/virtual-machines-windows-sql-automated-backup-v2.md
+++ b/articles/virtual-machines/windows/sql/virtual-machines-windows-sql-automated-backup-v2.md
@@ -32,13 +32,11 @@ To use Automated Backup v2, review the following prerequisites:
 
 **Operating System**:
 
-- Windows Server 2012 R2
-- Windows Server 2016
+- Windows Server 2012 R2 or higher
 
 **SQL Server version/edition**:
 
-- SQL Server 2016: Developer, Standard, or Enterprise
-- SQL Server 2017: Developer, Standard, or Enterprise
+- SQL Server 2016 or higher: Developer, Standard, or Enterprise
 
 > [!IMPORTANT]
 > Automated Backup v2 works with SQL Server 2016 or higher. If you are using SQL Server 2014, you can use Automated Backup v1 to back up your databases. For more information, see [Automated Backup for SQL Server 2014 Azure Virtual Machines](virtual-machines-windows-sql-automated-backup.md).


### PR DESCRIPTION
Change document to reflect that auto backup is supported for any version of SQL 2016  or higher /OS version of 2012 R2 or higher. @MashaMSFT 

