### PR TITLE
remove setting up 'Sign-on URL'

### DIFF
--- a/articles/active-directory/saas-apps/syxsense-tutorial.md
+++ b/articles/active-directory/saas-apps/syxsense-tutorial.md
@@ -86,11 +86,6 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
     b. In the **Reply URL** text box, type a URL using the following pattern:
     `https://<SUBDOMAIN>.cloudmanagementsuite.com/Saml2/Acs`
 
-1. Click **Set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
-
-    In the **Sign-on URL** text box, type a URL using the following pattern:
-    `https://<SUBDOMAIN>.cloudmanagementsuite.com/samlautologin`
-
 	> [!NOTE]
 	> These values are not real. Update these values with the actual Identifier, Reply URL and Sign-on URL. Contact [Syxsense Client support team](mailto:DevTeam@syxsense.com) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 


### PR DESCRIPTION
Many Syxsense customers experience issues when 'Sign-on URL' is setup as per tutorial, leaving it blank fixes the issue.

- Michael, Software Engineer at Syxsense