### PR TITLE
CA policy in report-only gives a message of not applicable

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-registration.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-registration.md
@@ -58,6 +58,7 @@ Some may choose to use device state instead of location in step 6 above:
 
 > [!WARNING]
 > If you use device state as a condition in your policy this may impact guest users in the directory. [Report-only mode](concept-conditional-access-report-only.md) can help determine the impact of policy decisions.
+> Note that report-only mode is not applicable for CA policies with "User Actions" scope.
 
 ## Next steps
 


### PR DESCRIPTION
According to case 120050522001804 and ICM https://portal.microsofticm.com/imp/v3/incidents/details/187386043/home if the user configures the CA policy to report-only mode, the message "Not Applied" is shown to the CX giving the false sensation that if the policy is enabled, the user won't be blocked from external accesses. As explained by the PG, this is by design and in this case, we consider this change in the documentation to have users aware about this CA policy in report-only mode.